### PR TITLE
Fix code scanning alert no. 61: Incomplete multi-character sanitization

### DIFF
--- a/extensions/azurePublish/package.json
+++ b/extensions/azurePublish/package.json
@@ -81,7 +81,8 @@
     "react-dom": "^16.13.0",
     "request": "2.88.2",
     "url-loader": "4.1.1",
-    "uuid": "8.3.2"
+    "uuid": "8.3.2",
+    "sanitize-html": "^2.13.0"
   },
   "resolutions": {
     "@botframework-composer/types": "file:../../Composer/packages/types",

--- a/extensions/azurePublish/src/components/util.ts
+++ b/extensions/azurePublish/src/components/util.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 import jwtDecode from 'jwt-decode';
+import sanitizeHtml from 'sanitize-html';
 
 import { AzureResourceTypes } from '../types';
 
@@ -17,7 +18,10 @@ export const removePlaceholder = (config: any) => {
   try {
     if (config) {
       let str = JSON.stringify(config);
-      str = str.replace(/<[^>]*>/g, '');
+      str = sanitizeHtml(str, {
+        allowedTags: [], // Remove all HTML tags
+        allowedAttributes: {} // Remove all attributes
+      });
       const newConfig = JSON.parse(str);
       return newConfig;
     } else {


### PR DESCRIPTION
Fixes [https://github.com/akabarki/my-chatbot/security/code-scanning/61](https://github.com/akabarki/my-chatbot/security/code-scanning/61)

To fix the problem, we should use a well-tested sanitization library that can handle complex cases and ensure effective sanitization. The `sanitize-html` library is a popular choice for this purpose. It allows us to remove unsafe HTML tags and attributes while keeping the safe ones.

1. Install the `sanitize-html` library.
2. Modify the `removePlaceholder` function to use `sanitize-html` for sanitization.
3. Ensure that the new implementation maintains the existing functionality of the `removePlaceholder` function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
