### PR TITLE
Fix code scanning alert no. 67: Incomplete string escaping or encoding

### DIFF
--- a/extensions/runtimes/src/index.ts
+++ b/extensions/runtimes/src/index.ts
@@ -28,8 +28,8 @@ const writeLocalFunctionsSetting = async (name: string, value: string, cwd: stri
   // only set if there is both a setting and a value.
   if (name && value && cwd) {
     // since these values could conceivably contain quote marks, make sure they are properly escaped
-    const escapedName = name.replace(/"/g, '\\"');
-    const escapedValue = value.replace(/"/g, '\\"');
+    const escapedName = name.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+    const escapedValue = value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
     const command = `func settings add "${escapedName}" "${escapedValue}"`;
     log('EXEC: ', command);
     const { stderr: err } = await execAsync(command, { cwd: cwd });


### PR DESCRIPTION
Fixes [https://github.com/akabarki/my-chatbot/security/code-scanning/67](https://github.com/akabarki/my-chatbot/security/code-scanning/67)

To fix the problem, we need to ensure that both double quotes and backslashes are properly escaped in the input strings. This can be achieved by using a regular expression with the global flag to replace all occurrences of double quotes and backslashes. We will use a well-tested sanitization library if available, but in this case, we will implement the escaping manually to ensure completeness.

1. Modify the `writeLocalFunctionsSetting` function to escape both double quotes and backslashes.
2. Use a regular expression with the global flag to replace all occurrences of double quotes and backslashes.
3. Ensure that the changes are made in the `extensions/runtimes/src/index.ts` file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
