### PR TITLE
Fix code scanning alert no. 72: Shell command built from environment values

### DIFF
--- a/Composer/packages/integration-tests/scripts/e2e.js
+++ b/Composer/packages/integration-tests/scripts/e2e.js
@@ -8,7 +8,7 @@
 
 const path = require('path');
 const { promisify } = require('util');
-const { spawn, execSync } = require('child_process');
+const { spawn, execSync, execFileSync } = require('child_process');
 
 const fs = require('fs-extra');
 const chalk = require('chalk');
@@ -90,7 +90,7 @@ async function run() {
 }
 
 function cleanup() {
-  execSync(`node ${path.resolve(__dirname, 'clean-e2e.js')}`); // lgtm [js/shell-command-injection-from-environment]
+  execFileSync('node', [path.resolve(__dirname, 'clean-e2e.js')]); // lgtm [js/shell-command-injection-from-environment]
 }
 
 console.clear();


### PR DESCRIPTION
Fixes [https://github.com/akabarki/my-chatbot/security/code-scanning/72](https://github.com/akabarki/my-chatbot/security/code-scanning/72)

To fix the problem, we should avoid constructing the shell command dynamically and instead use `execFileSync` to pass the command and its arguments separately. This approach ensures that the arguments are not interpreted by the shell, thus preventing command injection vulnerabilities.

1. Replace the `execSync` call with `execFileSync`.
2. Pass the command (`node`) and its arguments (`path.resolve(__dirname, 'clean-e2e.js')`) separately to `execFileSync`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
